### PR TITLE
Fix high CPU usage with configurable stats sampling intervals (Vibe Kanban)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,20 @@ type Config struct {
 
 	// Notifications (ntfy.sh)
 	Notifications *NotificationsConfig `json:"notifications,omitempty"`
+
+	// Stats sampling configuration
+	Stats *StatsConfig `json:"stats,omitempty"`
+}
+
+// StatsConfig represents statistics sampling configuration
+type StatsConfig struct {
+	// IdleSampleInterval is the sampling interval when no user is actively viewing (seconds)
+	// Default: 60 (1 minute)
+	IdleSampleInterval int `json:"idle_sample_interval,omitempty"`
+
+	// ActiveSampleInterval is the sampling interval when a user is actively viewing (seconds)
+	// Default: 2
+	ActiveSampleInterval int `json:"active_sample_interval,omitempty"`
 }
 
 // QoSConfig represents Quality of Service settings
@@ -395,6 +409,10 @@ func DefaultConfig() *Config {
 		Services: &ServicesConfig{
 			Enabled:  false,
 			Services: []Service{},
+		},
+		Stats: &StatsConfig{
+			IdleSampleInterval:   60, // 1 minute when idle
+			ActiveSampleInterval: 2,  // 2 seconds when active
 		},
 	}
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -4405,6 +4405,45 @@ func (s *Server) handleAPIStatsWiFiClientHistory(w http.ResponseWriter, r *http.
 	writeJSON(w, response)
 }
 
+// /api/stats/sampling - GET/POST stats sampling mode
+// GET returns current sampling status (active/idle mode and interval)
+// POST sets active mode (true = fast sampling for real-time UI, false = idle/slow sampling to save CPU)
+func (s *Server) handleAPIStatsSampling(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		// Return current sampling status
+		isActive := s.stats.IsActive()
+		interval := s.stats.GetSampleInterval()
+		writeJSON(w, map[string]interface{}{
+			"active":          isActive,
+			"interval_ms":     interval.Milliseconds(),
+			"interval_human":  interval.String(),
+		})
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		var req struct {
+			Active bool `json:"active"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		s.stats.SetActive(req.Active)
+
+		interval := s.stats.GetSampleInterval()
+		writeJSON(w, map[string]interface{}{
+			"active":          req.Active,
+			"interval_ms":     interval.Milliseconds(),
+			"interval_human":  interval.String(),
+		})
+		return
+	}
+
+	writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
+}
+
 // /api/qos/status - GET QoS status
 func (s *Server) handleAPIQoSStatus(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := s.ctx(r)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -275,8 +275,21 @@ func (s *Server) Run() error {
 		s.notifier.UpdateConnectedClients(ctx, clients)
 	})
 
-	// Start stats sampling in background
-	s.stats.StartSampling(ctx, stats.DefaultSampleInterval)
+	// Configure stats sampling intervals from config
+	idleInterval := stats.DefaultIdleSampleInterval
+	activeInterval := stats.DefaultActiveSampleInterval
+	if s.config.Stats != nil {
+		if s.config.Stats.IdleSampleInterval > 0 {
+			idleInterval = time.Duration(s.config.Stats.IdleSampleInterval) * time.Second
+		}
+		if s.config.Stats.ActiveSampleInterval > 0 {
+			activeInterval = time.Duration(s.config.Stats.ActiveSampleInterval) * time.Second
+		}
+	}
+	s.stats.SetSampleIntervals(idleInterval, activeInterval)
+
+	// Start stats sampling in background (starts in idle mode)
+	s.stats.StartSampling(ctx, idleInterval)
 
 	// Send system startup notification
 	go s.notifier.NotifySystemStartup(ctx)
@@ -490,6 +503,7 @@ func (s *Server) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("/api/stats/wifi/clients", s.requireAPIAuth(s.handleAPIStatsWiFiClients))
 	mux.HandleFunc("/api/stats/history", s.requireAPIAuth(s.handleAPIStatsHistory))
 	mux.HandleFunc("/api/stats/wifi-clients/history", s.requireAPIAuth(s.handleAPIStatsWiFiClientHistory))
+	mux.HandleFunc("/api/stats/sampling", s.requireAPIAuth(s.handleAPIStatsSampling))
 
 	// Devices
 	mux.HandleFunc("/api/devices", s.requireAPIAuth(s.handleAPIDevices))

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -14,9 +14,13 @@ import (
 
 const (
 	sysClassNet = "/sys/class/net"
-	// Default sample interval for rate calculations
-	DefaultSampleInterval = time.Second
-	// Default history size (keeps last 60 samples = 1 minute at 1s interval)
+	// DefaultIdleSampleInterval is the sampling interval when no user is actively viewing
+	DefaultIdleSampleInterval = 60 * time.Second
+	// DefaultActiveSampleInterval is the sampling interval when a user is actively viewing
+	DefaultActiveSampleInterval = 2 * time.Second
+	// DefaultSampleInterval is kept for backward compatibility (use idle interval)
+	DefaultSampleInterval = DefaultIdleSampleInterval
+	// Default history size (keeps last 60 samples)
 	DefaultHistorySize = 60
 )
 
@@ -126,7 +130,11 @@ type Manager struct {
 	wifiClients *WiFiClientManager
 
 	// Sampling configuration
-	sampleInterval time.Duration
+	sampleInterval       time.Duration
+	idleSampleInterval   time.Duration
+	activeSampleInterval time.Duration
+	isActive             bool
+	intervalChangeChan   chan time.Duration
 
 	// Background sampling
 	stopChan chan struct{}
@@ -142,15 +150,73 @@ type Manager struct {
 // New creates a new stats Manager.
 func New(fs system.FileSystem, runner system.CommandRunner) *Manager {
 	return &Manager{
-		fs:             fs,
-		runner:         runner,
-		history:        make(map[string][]sample),
-		historySize:    DefaultHistorySize,
-		latencyHistory: make([]LatencyStats, 0, DefaultHistorySize),
-		latencyTarget:  "8.8.8.8", // Default ping target
-		wifiClients:    NewWiFiClientManager(runner),
-		sampleInterval: DefaultSampleInterval,
+		fs:                   fs,
+		runner:               runner,
+		history:              make(map[string][]sample),
+		historySize:          DefaultHistorySize,
+		latencyHistory:       make([]LatencyStats, 0, DefaultHistorySize),
+		latencyTarget:        "8.8.8.8", // Default ping target
+		wifiClients:          NewWiFiClientManager(runner),
+		sampleInterval:       DefaultIdleSampleInterval,
+		idleSampleInterval:   DefaultIdleSampleInterval,
+		activeSampleInterval: DefaultActiveSampleInterval,
+		isActive:             false,
+		intervalChangeChan:   make(chan time.Duration, 1),
 	}
+}
+
+// SetSampleIntervals configures the idle and active sampling intervals.
+func (m *Manager) SetSampleIntervals(idle, active time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSampleInterval = idle
+	m.activeSampleInterval = active
+	// Update current interval based on active state
+	if m.isActive {
+		m.sampleInterval = active
+	} else {
+		m.sampleInterval = idle
+	}
+}
+
+// SetActive switches between active and idle sampling modes.
+// When active is true, sampling occurs more frequently for real-time UI updates.
+// When active is false, sampling occurs less frequently to save CPU.
+func (m *Manager) SetActive(active bool) {
+	m.mu.Lock()
+	wasActive := m.isActive
+	m.isActive = active
+	var newInterval time.Duration
+	if active {
+		newInterval = m.activeSampleInterval
+	} else {
+		newInterval = m.idleSampleInterval
+	}
+	m.sampleInterval = newInterval
+	m.mu.Unlock()
+
+	// Notify running sampler of interval change
+	if wasActive != active && m.running {
+		select {
+		case m.intervalChangeChan <- newInterval:
+		default:
+			// Channel full, sampler will pick up next tick
+		}
+	}
+}
+
+// IsActive returns whether the manager is in active sampling mode.
+func (m *Manager) IsActive() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.isActive
+}
+
+// GetSampleInterval returns the current sample interval.
+func (m *Manager) GetSampleInterval() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sampleInterval
 }
 
 // SetLatencyTarget sets the target for latency measurements.
@@ -490,6 +556,8 @@ func (m *Manager) GetSnapshot(ctx context.Context) (*StatsSnapshot, error) {
 }
 
 // StartSampling begins background sampling of statistics.
+// The interval parameter sets the initial sampling interval.
+// Use SetActive(true/false) to dynamically switch between active and idle intervals.
 func (m *Manager) StartSampling(ctx context.Context, interval time.Duration) {
 	m.mu.Lock()
 	if m.running {
@@ -498,6 +566,7 @@ func (m *Manager) StartSampling(ctx context.Context, interval time.Duration) {
 	}
 	m.running = true
 	m.stopChan = make(chan struct{})
+	m.sampleInterval = interval
 	store := m.store
 	m.mu.Unlock()
 
@@ -507,16 +576,15 @@ func (m *Manager) StartSampling(ctx context.Context, interval time.Duration) {
 		defer ticker.Stop()
 
 		// Take initial samples
-		_ = m.Sample(ctx)
-		_ = m.wifiClients.Sample(ctx)
-		m.recordWiFiClientSamples(ctx)
+		m.sampleAll(ctx)
 
 		for {
 			select {
 			case <-ticker.C:
-				_ = m.Sample(ctx)
-				_ = m.wifiClients.Sample(ctx)
-				m.recordWiFiClientSamples(ctx)
+				m.sampleAll(ctx)
+			case newInterval := <-m.intervalChangeChan:
+				// Dynamically change sampling interval
+				ticker.Reset(newInterval)
 			case <-m.stopChan:
 				return
 			case <-ctx.Done():
@@ -547,6 +615,18 @@ func (m *Manager) StartSampling(ctx context.Context, interval time.Duration) {
 			}
 		}()
 	}
+}
+
+// sampleAll takes all samples in a single pass, avoiding duplicate calls.
+func (m *Manager) sampleAll(ctx context.Context) {
+	// Sample interface stats
+	_ = m.Sample(ctx)
+
+	// Sample WiFi clients once
+	_ = m.wifiClients.Sample(ctx)
+
+	// Record WiFi client samples using cached data (avoid re-fetching)
+	m.recordWiFiClientSamplesFromCache(ctx)
 }
 
 // StopSampling stops background sampling.
@@ -607,6 +687,7 @@ func (m *Manager) QueryWiFiClientHistory(ctx context.Context, query WiFiClientHi
 }
 
 // recordWiFiClientSamples persists WiFi client samples to the store and triggers callbacks.
+// Note: This calls GetAllClientStats again. Prefer recordWiFiClientSamplesFromCache when possible.
 func (m *Manager) recordWiFiClientSamples(ctx context.Context) {
 	m.mu.RLock()
 	store := m.store
@@ -617,6 +698,30 @@ func (m *Manager) recordWiFiClientSamples(ctx context.Context) {
 	if err != nil {
 		return
 	}
+
+	// Persist to store
+	if store != nil {
+		for _, r := range rates {
+			_ = store.RecordWiFiClientSample(ctx, r)
+		}
+	}
+
+	// Call notification callback
+	if callback != nil {
+		callback(ctx, rates)
+	}
+}
+
+// recordWiFiClientSamplesFromCache persists WiFi client samples using already-cached data.
+// This avoids duplicate calls to GetAllClientStats that were made during Sample().
+func (m *Manager) recordWiFiClientSamplesFromCache(ctx context.Context) {
+	m.mu.RLock()
+	store := m.store
+	callback := m.onWiFiClientsSampled
+	m.mu.RUnlock()
+
+	// Use cached rates instead of re-fetching
+	rates := m.wifiClients.GetCachedRates()
 
 	// Persist to store
 	if store != nil {

--- a/internal/stats/wifi_clients.go
+++ b/internal/stats/wifi_clients.go
@@ -11,6 +11,9 @@ import (
 	"github.com/iodesystems/ubuntu-router/internal/system"
 )
 
+// Pre-compiled regex patterns for parsing iw station dump output
+var bitrateRegex = regexp.MustCompile(`(\d+\.?\d*)\s*MBit`)
+
 // WiFiClientStats represents raw statistics for a WiFi client
 type WiFiClientStats struct {
 	MAC           string    `json:"mac"`
@@ -61,6 +64,7 @@ type WiFiClientManager struct {
 	runner      system.CommandRunner
 	history     map[string][]wifiClientSample // key: MAC address
 	historySize int
+	cachedRates []WiFiClientRates // cached rates from last Sample() call
 }
 
 // NewWiFiClientManager creates a new WiFi client stats manager
@@ -163,14 +167,12 @@ func parseStationDump(iface, output string) []WiFiClientStats {
 			// Could track average signal too if needed
 
 		case strings.HasPrefix(line, "rx bitrate:"):
-			re := regexp.MustCompile(`(\d+\.?\d*)\s*MBit`)
-			if matches := re.FindStringSubmatch(line); len(matches) >= 2 {
+			if matches := bitrateRegex.FindStringSubmatch(line); len(matches) >= 2 {
 				current.RxBitrate, _ = strconv.ParseFloat(matches[1], 64)
 			}
 
 		case strings.HasPrefix(line, "tx bitrate:"):
-			re := regexp.MustCompile(`(\d+\.?\d*)\s*MBit`)
-			if matches := re.FindStringSubmatch(line); len(matches) >= 2 {
+			if matches := bitrateRegex.FindStringSubmatch(line); len(matches) >= 2 {
 				current.TxBitrate, _ = strconv.ParseFloat(matches[1], 64)
 			}
 
@@ -237,7 +239,8 @@ func parseStationDump(iface, output string) []WiFiClientStats {
 	return stats
 }
 
-// Sample takes a snapshot of all WiFi client statistics and stores it
+// Sample takes a snapshot of all WiFi client statistics and stores it.
+// It also computes and caches rates to avoid duplicate iw calls.
 func (m *WiFiClientManager) Sample(ctx context.Context) error {
 	stats, err := m.GetAllClientStats(ctx)
 	if err != nil {
@@ -277,7 +280,61 @@ func (m *WiFiClientManager) Sample(ctx context.Context) error {
 		}
 	}
 
+	// Compute and cache rates from the stats we already have (no extra iw calls)
+	m.cachedRates = m.computeRatesLocked(stats)
+
 	return nil
+}
+
+// computeRatesLocked calculates rates for all clients. Must be called with lock held.
+func (m *WiFiClientManager) computeRatesLocked(currentStats []WiFiClientStats) []WiFiClientRates {
+	var rates []WiFiClientRates
+	for _, s := range currentStats {
+		samples := m.history[s.MAC]
+
+		rate := WiFiClientRates{
+			MAC:           s.MAC,
+			Interface:     s.Interface,
+			Timestamp:     s.Timestamp,
+			Signal:        s.Signal,
+			RxBitrate:     s.RxBitrate,
+			TxBitrate:     s.TxBitrate,
+			TotalRxBytes:  s.RxBytes,
+			TotalTxBytes:  s.TxBytes,
+			ConnectedTime: s.ConnectedTime,
+			Inactive:      s.Inactive,
+			Authorized:    s.Authorized,
+		}
+
+		if len(samples) >= 2 {
+			newest := samples[len(samples)-1]
+			oldest := samples[0]
+
+			duration := newest.timestamp.Sub(oldest.timestamp).Seconds()
+			if duration > 0 {
+				rate.RxBytesPerSec = float64(newest.stats.RxBytes-oldest.stats.RxBytes) / duration
+				rate.TxBytesPerSec = float64(newest.stats.TxBytes-oldest.stats.TxBytes) / duration
+			}
+		}
+
+		rates = append(rates, rate)
+	}
+	return rates
+}
+
+// GetCachedRates returns the rates computed during the last Sample() call.
+// This avoids duplicate calls to GetAllClientStats.
+func (m *WiFiClientManager) GetCachedRates() []WiFiClientRates {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Return a copy to avoid data races
+	if m.cachedRates == nil {
+		return nil
+	}
+	result := make([]WiFiClientRates, len(m.cachedRates))
+	copy(result, m.cachedRates)
+	return result
 }
 
 // GetClientRates calculates rates for a specific client


### PR DESCRIPTION
## Summary

Fixes high CPU usage caused by aggressive stats sampling. The root causes were:

1. **1-second sampling interval** - Stats were being sampled every second, which is unnecessarily frequent for idle operation
2. **Duplicate WiFi client fetches** - The `iw` commands were being executed twice per sample cycle
3. **Regex compiled in hot path** - Bitrate regex was being compiled inside the parsing loop on every sample

## Changes Made

### Configuration (`internal/config/config.go`)
- Added new `StatsConfig` struct with configurable intervals:
  - `idle_sample_interval` (default: 60 seconds) - Used when no user is actively viewing
  - `active_sample_interval` (default: 2 seconds) - Used when UI needs real-time updates

### Stats Manager (`internal/stats/stats.go`)
- Added dynamic interval switching via `SetActive(true/false)` method
- New `sampleAll()` helper that avoids duplicate WiFi client fetches
- Added `recordWiFiClientSamplesFromCache()` to use cached data instead of re-fetching
- Sampling loop now listens for interval change signals to switch modes on-the-fly

### WiFi Client Stats (`internal/stats/wifi_clients.go`)
- Pre-compiled `bitrateRegex` at package level (was being compiled on every parse)
- Added `cachedRates` field to store computed rates during `Sample()`
- New `GetCachedRates()` method returns cached data without re-running `iw` commands

### API (`internal/server/api.go`, `internal/server/server.go`)
- Added `GET/POST /api/stats/sampling` endpoint:
  - `GET` returns current mode and interval
  - `POST {"active": true/false}` switches between fast/slow sampling
- Server now reads stats config and initializes intervals on startup

## Usage

The frontend should call `POST /api/stats/sampling {"active": true}` when the user navigates to stats-heavy pages (dashboard, wifi clients, etc.), and `{"active": false}` when they navigate away. This keeps CPU usage minimal during idle operation while still providing responsive real-time updates when needed.

Configuration example in `config.json`:
```json
{
  "stats": {
    "idle_sample_interval": 60,
    "active_sample_interval": 2
  }
}
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)