### PR TITLE
chore: add bin/t (validate without CI)

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Validate the repo without CI: catches build breaks (e.g. a dependency bump)
+# before code is merged/auto-merged.
+
+echo "==> go build ./..."
+go build ./...
+
+echo "==> go vet ./..."
+go vet ./...
+
+echo "==> make test"
+make test


### PR DESCRIPTION
## Summary
- Adds `bin/t`: a local validation script (`go build ./...` → `go vet ./...` → `make test`) that runs the same checks CI would, without CI.
- Intended to gate dependency-bump PRs before auto-merge — a bad bump that breaks the build or vet fails loudly and locally, before it lands.

## Verification
Ran `./bin/t` on a clean clone (Go 1.26.2):
- `go build ./...` — pass (after resolving deps)
- `go vet ./...` — pass
- `make test` (`go test -v ./...`) — pass (repo currently has no `_test.go` files, so this only confirms compilation of test binaries, not behavior)

## Test plan
- [x] `./bin/t` run locally, exits 0
- [ ] CI green on this PR